### PR TITLE
added instance statuses

### DIFF
--- a/acky/ec2.py
+++ b/acky/ec2.py
@@ -291,23 +291,22 @@ class InstanceCollection(AwsCollection, EC2ApiClient):
             params["filters"] = make_filters(filters)
         if instance_ids:
             params['InstanceIds'] = instance_ids
+        if all_instances is not None:
+            params['IncludeAllInstances'] = all_instances
         statuses = self.call("DescribeInstanceStatus",
-                                 response_data_key="InstanceStatuses",
-                                 **params)
+                             response_data_key="InstanceStatuses",
+                             **params)
         return statuses
 
-
     def events(self, all_instances=None, instance_ids=None, filters=None):
-        """a list of touples containing instance Id's and event information"""
+        """a list of tuples containing instance Id's and event information"""
         params = {}
         if filters:
             params["filters"] = make_filters(filters)
         if instance_ids:
             params['InstanceIds'] = instance_ids
-        statuses = self.call("DescribeInstanceStatus",
-                                 response_data_key="InstanceStatuses",
-                                 **params)
-        event_list=[]
+        statuses = self.status(all_instances, **params)
+        event_list = []
         for status in statuses:
             if status.get("Events"):
                 for event in status.get("Events"):


### PR DESCRIPTION
I'm looking for feedback - feel free to reject the PR once you've taken a gander.  I'm curious more or less about your thoughts on having ec2 instance events being first-class calls in addition to status; events are buried in status but I felt like there's some value to being able to say "lets see instance events." 
