### PR TITLE
Fixed issue that broke tests for 3.2

### DIFF
--- a/acky/ec2.py
+++ b/acky/ec2.py
@@ -313,7 +313,7 @@ class InstanceCollection(AwsCollection, EC2ApiClient):
         for status in statuses:
             if status.get("Events"):
                 for event in status.get("Events"):
-                    event[u"InstanceId"] = status.get('InstanceId')
+                    event['InstanceId'] = status.get('InstanceId')
                     event_list.append(event)
         return event_list
 


### PR DESCRIPTION
It seems that Python 3.2 has a bug with unicode keys. For example:

<pre>
> a = {}
> a[u"hi"] = 3
</pre>

will throw a `SyntaxError`.
This breaks the build on Travis.
